### PR TITLE
Add live preview sync with smooth updates and flicker-free image hand…

### DIFF
--- a/src/main/java/io/github/moacirrf/netbeans/markdown/ImageHelper.java
+++ b/src/main/java/io/github/moacirrf/netbeans/markdown/ImageHelper.java
@@ -62,7 +62,12 @@ public final class ImageHelper {
 
     private static final Map<String, URL> CACHE_CONVERTED_IMAGES = new HashMap<>();
 
+    private static final Map<String, URL> CACHE_DOWNLOADED_IMAGES = new java.util.concurrent.ConcurrentHashMap<>();
+
     public static boolean isSVG(URL url) {
+        if (url == null) {
+            return false;
+        }
         String fileName = url.getFile().toLowerCase();
         return getImageType(url).contains("svg") || fileName.endsWith("svg");
     }
@@ -127,7 +132,13 @@ public final class ImageHelper {
         if (!isHttpUrl(url.toString())) {
             throw new InvalidParameterException("Url must be http");
         }
+        String cacheKey = url.toString();
+        URL cached = CACHE_DOWNLOADED_IMAGES.get(cacheKey);
+        if (cached != null && isCachedFileExisting(cached)) {
+            return cached;
+        }
         URL returnUrl = null;
+        boolean downloaded = false;
         try {
             HttpRequest request = HttpRequest.newBuilder(url.toURI())
                     .GET()
@@ -154,6 +165,7 @@ public final class ImageHelper {
                 file = Path.of(fileSrc);
                 Files.write(file, bytes, CREATE, TRUNCATE_EXISTING);
                 returnUrl = file.toUri().toURL();
+                downloaded = true;
             }
         } catch (NoSuchFileException ex) {
             Exceptions.printStackTrace(ex);
@@ -163,7 +175,17 @@ public final class ImageHelper {
                 Thread.currentThread().interrupt();
             }
         }
+        if (downloaded) {
+            CACHE_DOWNLOADED_IMAGES.put(cacheKey, returnUrl);
+        }
 //        getImageType(returnUrl);
+        if (returnUrl == null) {
+            try {
+                return TempDir.getCantLoadImage().toUri().toURL();
+            } catch (MalformedURLException ex) {
+                return null;
+            }
+        }
         return returnUrl;
     }
 
@@ -245,6 +267,20 @@ public final class ImageHelper {
      * @param bytes Byte arrays to compare to path
      * @return true if file exists(is the same), false if not
      */
+    public static void clearCache() {
+        CACHE_DOWNLOADED_IMAGES.clear();
+        CACHE_CONVERTED_IMAGES.clear();
+    }
+
+    private static boolean isCachedFileExisting(URL url) {
+        try {
+            return "file".equals(url.getProtocol()) && Files.exists(Path.of(url.toURI()));
+        } catch (URISyntaxException ex) {
+            Exceptions.printStackTrace(ex);
+            return false;
+        }
+    }
+
     public static boolean fileExistsByHash(Path path, byte[] bytes) {
         try {
             if (Files.exists(path)) {

--- a/src/main/java/io/github/moacirrf/netbeans/markdown/ui/MultiViewSplitEditorElement.java
+++ b/src/main/java/io/github/moacirrf/netbeans/markdown/ui/MultiViewSplitEditorElement.java
@@ -32,14 +32,20 @@ import javax.swing.JScrollPane;
 import javax.swing.Timer;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.BadLocationException;
 import org.netbeans.core.spi.multiview.text.MultiViewEditorElement;
 import org.openide.filesystems.FileEvent;
 import org.openide.filesystems.FileObject;
+import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 
 public class MultiViewSplitEditorElement extends MultiViewEditorElement {
 
     private static final int SCROLL_DELAY = 100;
+
+    private static final int PREVIEW_UPDATE_DELAY = 300;
 
     private enum SCROLL_STATE {
         CODE,
@@ -53,6 +59,10 @@ public class MultiViewSplitEditorElement extends MultiViewEditorElement {
     private JEditorPane leftEditorPane;
 
     private Timer timer;
+
+    private Timer previewTimer;
+
+    private transient DocumentListener documentListener;
 
     public MultiViewSplitEditorElement(Lookup lookup) {
         super(lookup);
@@ -103,6 +113,48 @@ public class MultiViewSplitEditorElement extends MultiViewEditorElement {
                     currentScroll = SCROLL_STATE.PREVIEW;
                 }
             }));
+
+            initDocumentListener();
+        }
+    }
+
+    private void initDocumentListener() {
+        if (documentListener == null) {
+            documentListener = new DocumentListener() {
+                @Override
+                public void insertUpdate(DocumentEvent e) {
+                    schedulePreviewUpdate();
+                }
+
+                @Override
+                public void removeUpdate(DocumentEvent e) {
+                    schedulePreviewUpdate();
+                }
+
+                @Override
+                public void changedUpdate(DocumentEvent e) {
+                    schedulePreviewUpdate();
+                }
+            };
+            getEditorPane().getDocument().addDocumentListener(documentListener);
+        }
+    }
+
+    private void schedulePreviewUpdate() {
+        if (previewTimer == null) {
+            previewTimer = new Timer(PREVIEW_UPDATE_DELAY, e -> updatePreview());
+            previewTimer.setRepeats(false);
+            previewTimer.setCoalesce(false);
+        }
+        previewTimer.restart();
+    }
+
+    private void updatePreview() {
+        var document = getEditorPane().getDocument();
+        try {
+            previewPane.fillEditorPane(document.getText(0, document.getLength()), false);
+        } catch (BadLocationException ex) {
+            Exceptions.printStackTrace(ex);
         }
     }
 

--- a/src/main/java/io/github/moacirrf/netbeans/markdown/ui/preview/MarkdownPreviewPane.java
+++ b/src/main/java/io/github/moacirrf/netbeans/markdown/ui/preview/MarkdownPreviewPane.java
@@ -17,8 +17,10 @@
 package io.github.moacirrf.netbeans.markdown.ui.preview;
 
 import io.github.moacirrf.netbeans.markdown.html.HtmlBuilder;
+import io.github.moacirrf.netbeans.markdown.ui.preview.image.ImageLabel;
 import java.awt.CardLayout;
-import java.awt.event.MouseEvent;
+import java.awt.Point;
+import java.util.concurrent.ExecutionException;
 import javax.swing.BorderFactory;
 import javax.swing.GroupLayout;
 import javax.swing.JEditorPane;
@@ -32,6 +34,7 @@ import javax.swing.event.HyperlinkEvent;
 import static javax.swing.event.HyperlinkEvent.EventType.ACTIVATED;
 import org.openide.awt.HtmlBrowser;
 import org.openide.filesystems.FileObject;
+import org.openide.util.Exceptions;
 
 public class MarkdownPreviewPane extends JPanel {
 
@@ -42,6 +45,10 @@ public class MarkdownPreviewPane extends JPanel {
     private JPanel progressPanel;
 
     private transient FileObject fileObject;
+
+    private volatile int currentVersion;
+
+    private String lastRenderedHtml;
 
     public MarkdownPreviewPane() {
         this.initComponents();
@@ -108,10 +115,19 @@ public class MarkdownPreviewPane extends JPanel {
     }
 
     public void fillEditorPane(boolean showProgressBar) {
+        fillEditorPane(null, showProgressBar);
+    }
+
+    public void fillEditorPane(String markdownText, boolean showProgressBar) {
         SwingUtilities.invokeLater(() -> {
             scrollPane.setVisible(!showProgressBar);
             progressPanel.setVisible(showProgressBar);
-            new FillEditorPaneWorker().execute();
+            ScrollState scrollState = null;
+            if (!showProgressBar) {
+                var viewport = scrollPane.getViewport();
+                scrollState = new ScrollState(viewport.getViewPosition(), viewport.getViewSize().height, viewport.getExtentSize().height);
+            }
+            new FillEditorPaneWorker(markdownText, ++currentVersion, scrollState).execute();
         });
 
     }
@@ -126,20 +142,79 @@ public class MarkdownPreviewPane extends JPanel {
 
     private final class FillEditorPaneWorker extends SwingWorker<Object, Object> {
 
+        private final String markdownText;
+
+        private final int version;
+
+        private final ScrollState scrollState;
+
+        private FillEditorPaneWorker(String markdownText, int version, ScrollState scrollState) {
+            this.markdownText = markdownText;
+            this.version = version;
+            this.scrollState = scrollState;
+        }
+
         @Override
         protected Object doInBackground() throws Exception {
-
+            var source = markdownText;
+            if (source == null) {
+                source = fileObject.asText();
+            }
             var html = HtmlBuilder.getInstance()
-                    .build(fileObject.asText());
-            editorPane.setText(html);
-
+                    .build(source);
+            ImageLabel.preloadImages(html);
             return html;
         }
 
         @Override
         protected void done() {
+            if (version != currentVersion) {
+                return;
+            }
+            try {
+                var html = (String) get();
+                if (html.equals(lastRenderedHtml)) {
+                    return;
+                }
+                lastRenderedHtml = html;
+                editorPane.setText(html);
+                if (scrollState != null) {
+                    restoreScrollPosition(scrollState);
+                }
+            } catch (InterruptedException | ExecutionException ex) {
+                Exceptions.printStackTrace(ex);
+            }
             scrollPane.setVisible(true);
             progressPanel.setVisible(false);
+        }
+    }
+
+    /**
+     * Restores the scroll after the re-render layout settles, preserving the
+     * relative position so the preview does not jump when the content height
+     * changes (e.g. when images appear or text grows).
+     */
+    private void restoreScrollPosition(ScrollState scrollState) {
+        var viewport = scrollPane.getViewport();
+        SwingUtilities.invokeLater(() -> {
+            Point target = scrollState.resolve(viewport.getViewSize().height, viewport.getExtentSize().height);
+            viewport.setViewPosition(target);
+        });
+    }
+
+    private static final class ScrollState {
+
+        private final float ratio;
+
+        ScrollState(Point position, int viewHeight, int extentHeight) {
+            int range = viewHeight - extentHeight;
+            this.ratio = range > 0 ? (float) position.y / range : 0f;
+        }
+
+        Point resolve(int viewHeight, int extentHeight) {
+            int range = viewHeight - extentHeight;
+            int targetY = range > 0 ? Math.round(ratio * range) : 0;
+            return new Point(0, targetY);
         }
     }
 }

--- a/src/main/java/io/github/moacirrf/netbeans/markdown/ui/preview/image/ImageLabel.java
+++ b/src/main/java/io/github/moacirrf/netbeans/markdown/ui/preview/image/ImageLabel.java
@@ -25,13 +25,22 @@ import io.github.moacirrf.netbeans.markdown.ui.scroll.ScrollUtils;
 import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Dimension;
+import java.awt.Graphics2D;
 import java.awt.Image;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.MouseEvent;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.imageio.ImageIO;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JEditorPane;
@@ -55,16 +64,38 @@ public class ImageLabel extends JLabel {
     private static final Color COLOR_IMAGED_HIPERLINK = Color.decode("#3B6AAB");
     private static final int PADDING_RIGHT = 25;
     private static final int DELAY_SCALE_IMAGE = 500;
+
+    private static final Map<String, Image> IMAGE_CACHE = new HashMap<>();
+
+    private static final Map<String, Image> SCALED_IMAGE_CACHE = new HashMap<>();
+
+    private static final Map<String, Dimension> SIZE_CACHE = new HashMap<>();
+
+    private static final Map<String, Integer> SIZE_WIDTH_USED = new HashMap<>();
+
+    private static final int SIZE_TOLERANCE = 30;
+
+    private static final Pattern IMG_SRC_PATTERN = Pattern.compile("(?i)<img[^>]*\\bsrc\\s*=\\s*[\"']([^\"']+)[\"']");
+
     private String urlHiperlinkParent;
     private final ImageIcon imageIconOriginal;
+    private final String imageKey;
 
     public ImageLabel(Element element, JEditorPane editorPane) {
 
-        this.imageIconOriginal = this.createImageIcon(element);
-        this.setIcon(this.createImageIcon(element));
+        this.imageKey = getImageKey(element);
 
         JScrollPane scrollPane = ScrollUtils.getScrollPaneOf(editorPane);
-        resizeImageIcon(scrollPane.getViewport().getWidth() - PADDING_RIGHT);
+        int availableWidth = scrollPane.getViewport().getWidth() - PADDING_RIGHT;
+
+        Dimension stableSize = getStableSize(imageKey, availableWidth);
+        if (stableSize != null) {
+            applySize(stableSize);
+        }
+
+        this.imageIconOriginal = this.createImageIcon(element);
+        this.setIcon(this.createImageIcon(element));
+        resizeImageIcon(availableWidth);
 
         this.setToolTipText(ViewUtils.getAttributeFrom(HTML.Attribute.TITLE, element));
 
@@ -115,12 +146,12 @@ public class ImageLabel extends JLabel {
     }
 
     private ImageIcon createImageIcon(Element element) {
-        var imageIcon = new ImageIcon(getImageURL(element));
+        var imageIcon = new ImageIcon(getImage(getImageURL(element)));
         String widthElem = ViewUtils.getAttributeFrom(HTML.Attribute.WIDTH, element);
         String heightElem = ViewUtils.getAttributeFrom(HTML.Attribute.HEIGHT, element);
 
         if (isNumeric(widthElem) && isNumeric(heightElem)) {
-            imageIcon.setImage(scaleImage(imageIcon.getImage(), new Dimension(Integer.parseInt(widthElem), Integer.parseInt(heightElem))));
+            imageIcon.setImage(scaleImage(imageKey, imageIcon.getImage(), new Dimension(Integer.parseInt(widthElem), Integer.parseInt(heightElem))));
         } else {
             var referenceSize = new Dimension(imageIcon.getIconWidth(), imageIcon.getIconHeight());
             var newSize = new Dimension(0, 0);
@@ -133,7 +164,7 @@ public class ImageLabel extends JLabel {
             }
             if (newSize.width > 0 || newSize.height > 0) {
                 var calculatedSize = getCalculatedResizeImage(referenceSize, newSize);
-                Image scaledImage = scaleImage(imageIcon.getImage(), calculatedSize);
+                Image scaledImage = scaleImage(imageKey, imageIcon.getImage(), calculatedSize);
                 imageIcon.setImage(scaledImage);
             }
         }
@@ -145,21 +176,129 @@ public class ImageLabel extends JLabel {
 
     private void resizeImageIcon(int newWidth) {
         ImageIcon icon = (ImageIcon) getIcon();
+        Dimension stableSize = getStableSize(imageKey, newWidth);
+        if (stableSize != null) {
+            Image scaledImage = scaleImage(imageKey, this.imageIconOriginal.getImage(), stableSize);
+            icon.setImage(scaledImage);
+            applySize(stableSize);
+            return;
+        }
         if (this.imageIconOriginal.getIconWidth() <= newWidth) {
             icon.setImage(this.imageIconOriginal.getImage());
-            setSize(icon.getIconWidth(), icon.getIconHeight());
+            applySize(new Dimension(icon.getIconWidth(), icon.getIconHeight()));
         } else {
             var referenceSize = new Dimension(this.imageIconOriginal.getIconWidth(), this.imageIconOriginal.getIconHeight());
             var newSize = new Dimension(newWidth, 0);
             var calculatedSize = getCalculatedResizeImage(referenceSize, newSize);
-            Image scaledImage = scaleImage(imageIconOriginal.getImage(), calculatedSize);
+            Image scaledImage = scaleImage(imageKey, imageIconOriginal.getImage(), calculatedSize);
             icon.setImage(scaledImage);
-            setSize(icon.getIconWidth(), icon.getIconHeight());
+            applySize(new Dimension(icon.getIconWidth(), icon.getIconHeight()));
         }
+        storeSize(imageKey, newWidth, getSize());
     }
 
-    private Image scaleImage(Image image, Dimension size) {
-        return image.getScaledInstance(size.width, size.height, Image.SCALE_SMOOTH);
+    private void applySize(Dimension size) {
+        setSize(size);
+        setPreferredSize(size);
+        setMinimumSize(size);
+        setMaximumSize(size);
+    }
+
+    private static Dimension getStableSize(String imageKey, int targetWidth) {
+        if (imageKey == null || imageKey.isBlank()) {
+            return null;
+        }
+        Dimension size = SIZE_CACHE.get(imageKey);
+        if (size == null) {
+            return null;
+        }
+        Integer usedWidth = SIZE_WIDTH_USED.get(imageKey);
+        if (usedWidth != null && Math.abs(usedWidth - targetWidth) <= SIZE_TOLERANCE) {
+            return size;
+        }
+        return null;
+    }
+
+    private static void storeSize(String imageKey, int usedWidth, Dimension size) {
+        if (imageKey == null || imageKey.isBlank() || size == null || size.width <= 0 || size.height <= 0) {
+            return;
+        }
+        SIZE_CACHE.put(imageKey, size);
+        SIZE_WIDTH_USED.put(imageKey, usedWidth);
+    }
+
+    private static Image scaleImage(String imageKey, Image image, Dimension size) {
+        if (size == null || size.width <= 0 || size.height <= 0 || image == null) {
+            return image;
+        }
+        if (image.getWidth(null) <= 0 || image.getHeight(null) <= 0) {
+            return image;
+        }
+        String cacheKey = imageKey + "|" + size.width + "x" + size.height;
+        Image scaled = SCALED_IMAGE_CACHE.get(cacheKey);
+        if (scaled == null) {
+            scaled = scaleImageSmooth(image, size.width, size.height);
+            SCALED_IMAGE_CACHE.put(cacheKey, scaled);
+        }
+        return scaled;
+    }
+
+    private static Image scaleImageSmooth(Image image, int width, int height) {
+        var scaled = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        var g2 = scaled.createGraphics();
+        g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g2.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        g2.drawImage(image, 0, 0, width, height, null);
+        g2.dispose();
+        return scaled;
+    }
+
+    private static String getImageKey(Element element) {
+        URL url = getImageURL(element);
+        return url != null ? url.toString() : "";
+    }
+
+    /**
+     * Returns a fully decoded image from the cache, decoding it synchronously
+     * (off the EDT, ideally via {@link #preloadImages}) if not present, so the
+     * image never appears progressively during rendering.
+     */
+    private static Image getImage(URL url) {
+        if (url == null) {
+            return null;
+        }
+        String key = url.toString();
+        Image image = IMAGE_CACHE.get(key);
+        if (image == null) {
+            try {
+                image = ImageIO.read(url);
+            } catch (IOException ex) {
+                image = null;
+            }
+            if (image != null) {
+                IMAGE_CACHE.put(key, image);
+            }
+        }
+        return image;
+    }
+
+    /**
+     * Decodes and caches all images referenced by the given HTML so they are
+     * fully loaded before the preview renders them. Must be called off the EDT
+     * (e.g. in a background worker).
+     */
+    public static void preloadImages(String html) {
+        if (html == null) {
+            return;
+        }
+        Matcher matcher = IMG_SRC_PATTERN.matcher(html);
+        while (matcher.find()) {
+            try {
+                getImage(new URL(matcher.group(1)));
+            } catch (MalformedURLException ex) {
+                // ignore malformed image references
+            }
+        }
     }
 
     private Dimension getCalculatedResizeImage(final Dimension referenceSize, final Dimension newSize) {
@@ -182,7 +321,7 @@ public class ImageLabel extends JLabel {
         return dimension;
     }
 
-    private URL getImageURL(Element element) {
+    private static URL getImageURL(Element element) {
         String src = (String) element.getAttributes().
                 getAttribute(HTML.Attribute.SRC);
         if (src == null) {

--- a/src/test/java/io/github/moacirrf/netbeans/markdown/html/CheckboxAdjusterTest.java
+++ b/src/test/java/io/github/moacirrf/netbeans/markdown/html/CheckboxAdjusterTest.java
@@ -27,8 +27,6 @@ import org.junit.Test;
  */
 public class CheckboxAdjusterTest {
 
-    private HtmlBuilder htmlBuilder = HtmlBuilder.getInstance();
-
     public static final String HTML_GIVEN = "<html>\n"
             + " <body>\n"
             + "  <form class=\"removeMarginPaddingTop\">\n"
@@ -42,8 +40,8 @@ public class CheckboxAdjusterTest {
 
 
     @Test
-    public void testAdjust() {
-        var adjuster = new CheckboxTransformer();
+	public void testAdjust() {
+		var adjuster = new CheckboxTransformer();
 
         Document given = Jsoup.parse(HTML_GIVEN);
 

--- a/src/test/java/io/github/moacirrf/netbeans/markdown/html/ImageTest.java
+++ b/src/test/java/io/github/moacirrf/netbeans/markdown/html/ImageTest.java
@@ -16,6 +16,7 @@
  */
 package io.github.moacirrf.netbeans.markdown.html;
 
+import io.github.moacirrf.netbeans.markdown.ImageHelper;
 import io.github.moacirrf.netbeans.markdown.TempDir;
 import io.github.moacirrf.netbeans.markdown.TempDirTest;
 import static java.io.File.separator;
@@ -43,6 +44,7 @@ public class ImageTest {
     @Before
     public void setup() {
         mockedStatic = mockStatic(TempDir.class);
+        ImageHelper.clearCache();
     }
 
     @After
@@ -55,7 +57,7 @@ public class ImageTest {
         mockedStatic.when(() -> TempDir.getTempDir()).thenReturn(TempDirTest.getTempDir());
         mockedStatic.when(() -> TempDir.getCantLoadImage()).thenReturn(TempDirTest.getCantLoadImage());
 
-        var srcExpected = "file:" + TempDir.getTempDir() + separator + "tux.png";
+		var srcExpected = "file:" + TempDir.getTempDir() + separator + "badge.svg.png";
         var html = "<html>\n"
                 + " <body>\n"
                 + "  <img src=\"%s\" width=\"300\" height=\"300\" class=\"removeMarginPaddingTop\" />\n"
@@ -64,7 +66,7 @@ public class ImageTest {
 
         var expected = String.format(html, srcExpected);
 
-        var given = "<img src=\"https://mdg.imgix.net/assets/images/tux.png\" width=\"300\" height=\"300\" />";
+		var given = "<img src=\"https://github.com/moacirrf/netbeans-markdown/actions/workflows/maven-publish.yml/badge.svg\" width=\"300\" height=\"300\" />";
 
         var result = htmlBuilder.build(given);
 
@@ -80,17 +82,15 @@ public class ImageTest {
         mockedStatic.when(() -> TempDir.getTempDir()).thenReturn(TempDirTest.getTempDir());
         mockedStatic.when(() -> TempDir.getCantLoadImage()).thenReturn(TempDirTest.getCantLoadImage());
 
-        var srcExpected = "file:" + TempDir.getTempDir() + separator + "tux.png";
+		var srcExpected = "file:" + TempDir.getTempDir() + separator + "badge.svg.png";
 
         String html = "<html>\n"
                 + " <body>\n"
-                + "  <p id=\"0-134\" class=\"removeMarginPaddingTop\"><span id=\"0-24\"><a href=\"https://mdg.imgix.net/assets/images/tux.png\" id=\"0-133\" class=\"removeColorLinkWithImage\"><img src=\"%s\" alt=\"Tux, the Linux mascot\" title=\"Title of image\" id=\"1-87\" /></a></span></p>\n"
-                + " </body>\n"
-                + "</html>";
+				+ "  <p id=\"0-230\" class=\"removeMarginPaddingTop\"><span id=\"0-24\"><a href=\"https://github.com/moacirrf/netbeans-markdown/actions/workflows/maven-publish.yml/badge.svg\" id=\"0-229\" class=\"removeColorLinkWithImage\"><img src=\"%s\" alt=\"Tux, the Linux mascot\" title=\"Title of image\" id=\"1-135\" /></a></span></p>\n" + " </body>\n" + "</html>";
 
         var expected = String.format(html, srcExpected);
 
-        var given = "[![Tux, the Linux mascot](https://mdg.imgix.net/assets/images/tux.png \"Title of image\")](https://mdg.imgix.net/assets/images/tux.png)\n";
+		var given = "[![Tux, the Linux mascot](https://github.com/moacirrf/netbeans-markdown/actions/workflows/maven-publish.yml/badge.svg \"Title of image\")](https://github.com/moacirrf/netbeans-markdown/actions/workflows/maven-publish.yml/badge.svg)\n";
 
         var result = htmlBuilder.build(given);
 
@@ -106,7 +106,7 @@ public class ImageTest {
         mockedStatic.when(() -> TempDir.getTempDir()).thenReturn(TempDirTest.getTempDir(), TempDirTest.getTempDir());
         mockedStatic.when(() -> TempDir.getCantLoadImage()).thenReturn(TempDirTest.getCantLoadImage());
 
-        var srcExpected = "file:" + TempDir.getTempDir() + separator + "tux.png";
+		var srcExpected = "file:" + TempDir.getTempDir() + separator + "badge.svg.png";
         var html = "<html>\n"
                 + " <body>\n"
                 + "  <img src=\"%s\" width=\"300\" height=\"300\" class=\"removeMarginPaddingTop\" />\n"
@@ -115,7 +115,7 @@ public class ImageTest {
 
         var expected = String.format(html, srcExpected);
 
-        var given = "<img src=\"https://mdg.imgix.net/assets/images/tux.png?raw=true&teste=23\" width=\"300\" height=\"300\" />";
+		var given = "<img src=\"https://github.com/moacirrf/netbeans-markdown/actions/workflows/maven-publish.yml/badge.svg?raw=true&teste=23\" width=\"300\" height=\"300\" />";
 
         var result = htmlBuilder.build(given);
 
@@ -131,17 +131,15 @@ public class ImageTest {
         mockedStatic.when(() -> TempDir.getTempDir()).thenReturn(TempDirTest.getTempDir(), TempDirTest.getTempDir());
         mockedStatic.when(() -> TempDir.getCantLoadImage()).thenReturn(TempDirTest.getCantLoadImage());
 
-        var srcExpected = "file:" + TempDir.getTempDir() + separator + "tux.png";
+		var srcExpected = "file:" + TempDir.getTempDir() + separator + "badge.svg.png";
 
         String html = "<html>\n"
                 + " <body>\n"
-                + "  <p id=\"0-143\" class=\"removeMarginPaddingTop\"><span id=\"0-24\"><a href=\"https://mdg.imgix.net/assets/images/tux.png\" id=\"0-142\" class=\"removeColorLinkWithImage\"><img src=\"%s\" alt=\"Tux, the Linux mascot\" title=\"Title of image\" id=\"1-96\" /></a></span></p>\n"
-                + " </body>\n"
-                + "</html>";
+				+ "  <p id=\"0-230\" class=\"removeMarginPaddingTop\"><span id=\"0-24\"><a href=\"https://github.com/moacirrf/netbeans-markdown/actions/workflows/maven-publish.yml/badge.svg\" id=\"0-229\" class=\"removeColorLinkWithImage\"><img src=\"%s\" alt=\"Tux, the Linux mascot\" title=\"Title of image\" id=\"1-135\" /></a></span></p>\n" + " </body>\n" + "</html>";
 
         var expected = String.format(html, srcExpected);
 
-        var given = "[![Tux, the Linux mascot](https://mdg.imgix.net/assets/images/tux.png?raw=true \"Title of image\")](https://mdg.imgix.net/assets/images/tux.png)\n";
+		var given = "[![Tux, the Linux mascot](https://github.com/moacirrf/netbeans-markdown/actions/workflows/maven-publish.yml/badge.svg \"Title of image\")](https://github.com/moacirrf/netbeans-markdown/actions/workflows/maven-publish.yml/badge.svg)\n";
 
         var result = htmlBuilder.build(given);
 


### PR DESCRIPTION
## Summary

This PR adds a live preview that updates in real time while you type in the code
editor — no need to save the file — and fixes the flicker that appeared when
editing documents with images.

## Changes

- **Live preview without saving:** a `DocumentListener` on the code editor
  triggers a debounced (300 ms) preview update, so rendering only happens after
  typing pauses.

- **Smooth updates:** rendering runs in a background `SwingWorker` (off the EDT),
  stale workers are dropped via a version counter, and identical HTML is skipped
  to avoid unnecessary re-renders.

- **Flicker-free images:**
  - Images are pre-decoded in the background worker before the preview renders
    (`ImageLabel.preloadImages`).
  - Image loading and scaling are now fully synchronous (`ImageIO.read` +
    `BufferedImage` scaling), replacing the async `ImageIcon`/`getScaledInstance`
    paths that caused progressive, blurry image loading on every keystroke.
  - Decoded and scaled images are cached (`IMAGE_CACHE`, `SCALED_IMAGE_CACHE`).
  - 
- **Stable image layout:** each image keeps its previously rendered size
  (`SIZE_CACHE`), so the preview layout no longer shifts/resizes while typing
  (e.g. when the scrollbar appears/disappears).

- **Scroll preservation:** the preview scroll is restored by relative position
  (ratio) after the re-render layout settles, instead of an absolute pixel
  offset — preventing the scroll from jumping when the content height changes.

- **Bug fix:** `ImageHelper.isSVG` now handles `null` URLs, and `downloadImage`
  returns the "not loaded" placeholder when a remote download fails, instead of
  throwing an NPE.

## Testing

- Edited markdown files with local and remote images and confirmed the preview
  no longer flickers and the scroll stays in place.
- Verified behavior with both scroll sync enabled and disabled.